### PR TITLE
static components and routing

### DIFF
--- a/src/css/classes/wrappers.css
+++ b/src/css/classes/wrappers.css
@@ -1,9 +1,10 @@
 .mainContentWrapper {
+  margin: 0 auto;
   max-width: 700px;
 }
 
 .pageWrapper {
-    margin: 0;
+    margin: 0 auto;
     padding : 0 20px;
 }
 

--- a/src/js/components/about/about.css
+++ b/src/js/components/about/about.css
@@ -1,0 +1,39 @@
+:import('../../../css/classes/headings.css') {
+    subHeading: subHeading;
+    secondaryHeading: secondaryHeading;
+}
+
+:import('../../../css/classes/links.css') {
+    linkDefaults: linkDefaults;
+}
+
+:import('../../../css/rules/fonts.css') {
+    body: body;
+}
+
+:import('../../../css/rules/palette.css') {
+    linkColor: linkColor;
+}
+
+.content {
+    composes: mainContentWrapper from '../../../css/classes/wrappers.css';
+    font-family: body;
+}
+
+.heading {
+    composes: secondaryHeading;
+}
+
+.subHeading {
+    composes: subHeading;
+}
+
+.link {
+    composes: linkDefaults;
+    color: linkColor;
+    text-decoration: underline;
+}
+
+.content img {
+  max-width: 100%;
+}

--- a/src/js/components/about/index.js
+++ b/src/js/components/about/index.js
@@ -1,7 +1,42 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+    content,
+    heading,
+    link
+} from './about.css';
 
 const About = () => (
-    <div>About page</div>
+    <main className={content} role="main">
+        <article>
+            <p>
+                <img src="http://www.freeformportland.org/wp-content/uploads/2016/01/thought-crime.jpg" alt="thought-crime" />
+            </p>
+            <h2 className={heading}>About Freeform Portland</h2>
+            <p>Freeform Portland is a nonprofit, independent, community-driven radio station broadcasting live at KFFP-LP
+                90.3 FM in North Portland, and streaming online at <Link className={link} to="/listen">freeformportland.org/listen</Link>.
+                Our purpose is to foster independent, local, experimental, and underground music alongside arts and public
+                affairs programming that authentically reflects our communities. Freeform Portland is a 501(c)(3) entity,
+                classified by the IRS as a charitable organization, and gratefully accepting tax-deductible <Link className={link}to="/donate">donations</Link>.</p>
+            <h2 className={heading}>Community-Driven</h2>
+            <p>We need more community radio. For a city with a metro area of over two million creative people, Portland
+                has a surprisingly small number of non-commercial, independent radio stations on the air. Three companies
+                control the majority of FM radio stations broadcasting in our city. Community radio provides an invaluable
+                venue for more voices to be heard and more perspectives to be represented in public media. We love local
+                stations like KBOO, KMHD, and XRAY. Freeform Portland is proud to join them in taking back the airwaves
+                from corporate control.</p>
+            <h2 className={heading}>Freeform Radio</h2>
+            <p>What is freeform radio? Freeform radio is a programming format in which the DJ is given total control over
+                what to play, regardless of music genre or commercial interests. Freeform radio stands in contrast to
+                most commercial radio stations where DJs have little or no influence over programming structure or playlists.
+                Ken Freedman from WFMU (the longest-running freeform radio station in the United States) explains the
+                importance of freeform radio and what Freeform Portland is up to <a className={link}
+                    href="https://www.youtube.com/watch?v=Z-qEUkYWnck"
+                    target="_blank"
+                >here</a>.</p>
+
+        </article>
+    </main>
 );
 
 export default About;

--- a/src/js/components/donate/donate.css
+++ b/src/js/components/donate/donate.css
@@ -1,0 +1,35 @@
+:import('../../../css/classes/headings.css') {
+    subHeading: subHeading;
+    secondaryHeading: secondaryHeading;
+}
+
+:import('../../../css/classes/links.css') {
+    linkDefaults: linkDefaults;
+}
+
+:import('../../../css/rules/fonts.css') {
+    body: body;
+}
+
+:import('../../../css/rules/palette.css') {
+    linkColor: linkColor;
+}
+
+.content {
+    composes: mainContentWrapper from '../../../css/classes/wrappers.css';
+    font-family: body;
+}
+
+.heading {
+    composes: secondaryHeading;
+}
+
+.subHeading {
+    composes: subHeading;
+}
+
+.link {
+    composes: linkDefaults;
+    color: linkColor;
+    text-decoration: underline;
+}

--- a/src/js/components/donate/index.js
+++ b/src/js/components/donate/index.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+    content,
+    heading,
+    link
+} from './donate.css';
+
+const Donate = () => (
+    <main role="main" className={content}>
+        <article>
+            <div>
+                <h1>Donate</h1>
+                <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top"><input name="cmd" type="hidden" value="_s-xclick" /><input name="hosted_button_id" type="hidden" value="EXDPWNQFGWYEL" /><input alt="Donate to KFFP" name="submit" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" type="image" /></form>
+                <p>Freeform Portland is a 501(c)(3) organization gratefully accepting tax-deductible donations through PayPal (&#8220;Donate&#8221; link above) or by check. You can also keep an eye out for the donation jar at our events. Please make any checks out to “Freeform Portland” and mail to:</p>
+                <p>Freeform Portland<br />
+                    c/o Donations<br />
+                    5511 N. Albina Ave.<br />
+                    Portland OR 97217</p>
+                <p>We also love donations of records, CDs and headphones in good working condition, plus office supplies, snacks, and more. If you’d like to make a donation like this, please email donate@freeformportland.org to get in touch. Our station runs on support from our friends and neighbors and we appreciate any and all contributions!</p>
+                <p>Freeform Portland KFFP-LP 90.3 FM benefits our communities in the following ways:</p>
+                <ul>
+                    <li>Hosting free public broadcasting classes and music education opportunities</li>
+                    <li>Featuring a vast and diverse mix of DJs with unique cultural perspectives and fresh voices</li>
+                    <li>Providing exposure to local and touring musicians</li>
+                    <li>Broadcasting experimental music and arts programming, which we believe are under-represented in Portland</li>
+                </ul>
+                <p>We’re proud to uphold community radio and freeform programming in ways that benefit and deeply resonate with our listeners.</p>
+                <p>Can’t donate? <Link className={link} to="/volunteer">Help out!</Link></p>
+                <p>Thanks so much!</p>
+                <p>— KFFP Volunteers</p>
+            </div>
+        </article>
+    </main>
+);
+
+export default Donate;

--- a/src/js/components/faq/faq.css
+++ b/src/js/components/faq/faq.css
@@ -1,0 +1,35 @@
+:import('../../../css/classes/headings.css') {
+    subHeading: subHeading;
+    secondaryHeading: secondaryHeading;
+}
+
+:import('../../../css/classes/links.css') {
+    linkDefaults: linkDefaults;
+}
+
+:import('../../../css/rules/fonts.css') {
+    body: body;
+}
+
+:import('../../../css/rules/palette.css') {
+    linkColor: linkColor;
+}
+
+.content {
+    composes: mainContentWrapper from '../../../css/classes/wrappers.css';
+    font-family: body;
+}
+
+.heading {
+    composes: secondaryHeading;
+}
+
+.subHeading {
+    composes: subHeading;
+}
+
+.link {
+    composes: linkDefaults;
+    color: linkColor;
+    text-decoration: underline;
+}

--- a/src/js/components/faq/index.js
+++ b/src/js/components/faq/index.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+    content,
+    heading,
+    subHeading,
+    link
+} from './faq.css';
+
+const Faq = () => (
+    <main role="main" className={content}>
+        <article>
+            <h1 className={heading}>FAQ</h1>
+            <h3 className={subHeading}>How can I donate? Are donations tax deductible?</h3>
+            <ul>
+                <li>Yes, donations are tax deductible. Our station has 501(c)(3) status, which means the IRS classifies us as a charitable organization. Freeform Portland gratefully accepts donations through <Link className={link} to="/donate">PayPal</Link> or by check. We also love donations of records, CDs and headphones in good and working condition. Our station runs on support from our friends and neighbors and we are grateful for any and all contributions! Please visit our <Link to="/donate" className={link}>Donate page</Link> for more information.</li>
+            </ul>
+            <h3 className={subHeading}>What&#8217;s the Frequency, Kenneth? How old is the station?</h3>
+            <ul>
+                <li>Freeform Portland went on the air at 90.3 FM in north Portland in April 2016. Our full call sign is KFFP-LP 90.3 FM. (The &#8220;LP&#8221; stands for &#8220;low power.&#8221;)</li>
+            </ul>
+            <h3 className={subHeading}>Where can I get the best signal for Freeform Portland?</h3>
+            <ul>
+                <li>Our transmitter is located in the NE Alberta neighborhood in Portland, OR. We&#8217;re a low-power FM station, which means our range has an approximate 5-mile radius. Your reception will vary depending on your equipment, distance from the transmitter, and the height of the buildings in between. We also stream online at <a className={link}href="http://www.freeformportland.org/listen">www.freeformportland.org/listen</a>.</li>
+            </ul>
+            <h3 className={subHeading}>Can I have a show?</h3>
+            <ul>
+                <li>Yes! All on-air DJs must first complete at least 5 volunteer hours each month, and complete DJ training with Freeform Portland.</li>
+                <li>Freeform Portland changes our schedule every 6 months and the new cycle starts April 1st. Follow <a className={link} href="https://docs.google.com/forms/d/e/1FAIpQLSfw_PiWa1IXdUZN0wHUGq9JHysHWJrEE4u-6Y-7kw0CdvbcLw/viewform" target="_blank">this link</a> for more information and to apply for a show. If you are interested in having a show in the new cycle, you will need to apply by February 18th, 2017.</li>
+            </ul>
+            <h3 className={subHeading}>What about volunteer opportunities? How can I help?</h3>
+            <ul>
+                <li>Yes, we have <Link className={link} to="/volunteer">many volunteer opportunities</Link>. To find out more, please fill out our <a className={link} href="https://docs.google.com/forms/d/118lWyMgnMCVz3_xNOwMkUqXjYDnjq3wJPpVorB3BaBk/viewform?c=0&amp;w=1" target="_blank">KFFP Volunteer Contact Form</a>.</li>
+            </ul>
+            <h3 className={subHeading}>Will you play my band&#8217;s album?</h3>
+            <ul>
+                <li>Most likely! Music adhering to FCC regulations is eligible to be played on our station. Send music to:</li>
+            </ul>
+            <p>Freeform Portland<br />
+                c/o Music Library<br />
+                5511 N Albina Ave.<br />
+                Portland OR 97217</p>
+            <h3 className={subHeading}>Are there commercials?</h3>
+            <ul>
+                <li>No! Freeform Portland is a nonprofit, commercial-free radio station. We&#8217;re using the same engineering team that created KZME and XRAY and working alongside other non-commercial radio stations in Portland.</li>
+            </ul>
+            <h3 className={subHeading}>Where&#8217;s the studio located?</h3>
+            <ul>
+                <li>We&#8217;re at 5511 N Albina Ave. in Portland, Oregon. (Our cross street is Killingsworth.)</li>
+            </ul>
+            <h3 className={subHeading}>Are you selling merch?</h3>
+            <ul>
+                <li>Yes, we have a variety of things in stock — normally we have t-shirts, koozies, bottle opener key chains, stickers, and more. Keep an eye out for our merch table at KFFP-sponsored events.</li>
+            </ul>
+        </article>
+    </main>
+);
+
+export default Faq;

--- a/src/js/components/landing/index.js
+++ b/src/js/components/landing/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+    content,
+    heading,
+    link
+} from './landing.css';
+
+const Landing = () => (
+    <main role="main" className={content}>
+        <article>
+            <div>
+                <p><img src="http://www.freeformportland.org/wp-content/uploads/2016/01/Zach-Stricker-KFFP-Image.jpg" alt="KFFP Image by Zach Stricker" /></p>
+                <h1 className={heading}>Liberate the Local Airwaves</h1>
+                <p>Freeform Portland KFFP-LP 90.3 FM is run by a dedicated group of music enthusiasts and DJs from Portland, Oregon. We&#8217;re local volunteers who want to reclaim some portion of our airwaves from corporate control.</p>
+                <p>We offer:</p>
+                <ul>
+                    <li>Public broadcasting classes and music education opportunities</li>
+                    <li>DJs with unique cultural perspectives and fresh voices from the local community</li>
+                    <li>Exposure to local and touring musicians</li>
+                    <li>Experimental music and arts programming, under-represented in Portland</li>
+                </ul>
+                <p>Let&#8217;s uphold community radio and freeform programming that truly reflects and celebrates our local communities.</p>
+                <p><Link className={link} to="/donate">Donate to KFFP!</Link></p>
+                <p>Can&#8217;t donate? <Link to="/volunteer" className={link}>Help out!</Link></p>
+                <p>&nbsp;</p>
+            </div>
+        </article>
+    </main>
+);
+
+export default Landing;

--- a/src/js/components/landing/landing.css
+++ b/src/js/components/landing/landing.css
@@ -1,0 +1,39 @@
+:import('../../../css/classes/headings.css') {
+    subHeading: subHeading;
+    secondaryHeading: secondaryHeading;
+}
+
+:import('../../../css/classes/links.css') {
+    linkDefaults: linkDefaults;
+}
+
+:import('../../../css/rules/fonts.css') {
+    body: body;
+}
+
+:import('../../../css/rules/palette.css') {
+    linkColor: linkColor;
+}
+
+.content {
+    composes: mainContentWrapper from '../../../css/classes/wrappers.css';
+    font-family: body;
+}
+
+.heading {
+    composes: secondaryHeading;
+}
+
+.subHeading {
+    composes: subHeading;
+}
+
+.link {
+    composes: linkDefaults;
+    color: linkColor;
+    text-decoration: underline;
+}
+
+.content img {
+  max-width: 100%;
+}

--- a/src/js/components/nav/index.js
+++ b/src/js/components/nav/index.js
@@ -42,13 +42,13 @@ class NavBar extends Component {
                         <li className={about}>
                             <Link className={navLink} to="/about">About</Link>
                             <ul className={subMenu}>
-                                <li><a className={navLink} href="#volunteer">Volunteer</a></li>
-                                <li><a className={navLink} href="#underwriting">Underwriting</a></li>
-                                <li><a className={navLink} href="#faq">FAQ</a></li>
+                                <li><Link className={navLink} to="/volunteer">Volunteer</Link></li>
+                                <li><Link className={navLink} to="/underwriting">Underwriting</Link></li>
+                                <li><Link className={navLink} to="/faq">FAQ</Link></li>
                             </ul>
                         </li>
-                        <li><a className={navLink} href="#schedule">Schedule</a></li>
-                        <li><a className={navLink} href="#donate">Donate</a></li>
+                        <li><Link className={navLink} to="/schedule">Schedule</Link></li>
+                        <li><Link className={navLink} to="/donate">Donate</Link></li>
                     </ul>
                     <ul className={`${social} ${this.state.displayMenu ? toggleMenu : ''}`}>
                         <li>

--- a/src/js/components/nav/nav.css
+++ b/src/js/components/nav/nav.css
@@ -135,6 +135,7 @@
 .toggleMenu {
   display: block;
 }
+
 .facebook {
   composes: faDefaults facebookLogo;
 }
@@ -146,8 +147,6 @@
 .twitter {
   composes: faDefaults twitterLogo;
 }
-
-
 
 @media only screen and (min-width: 600px) {
   .social {
@@ -191,7 +190,7 @@
   }
 
   .about > a:after {
-    /* fa-angle-down */
+
     content: "\f107";
     font-family: FontAwesome;
     margin-left: 5px;

--- a/src/js/components/underwriting/index.js
+++ b/src/js/components/underwriting/index.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+    link,
+    content
+} from './underwriting.css'
+
+const Underwriting = () => (
+    <main className={content}>
+        <article>
+            <p>Freeform Portland is excited to have the opportunity to support local businesses on air! Your business can receive on-air mentions where we will highlight your goods and services and include your name on our website.  If this interests you, contact <a>underwriting@freeformportland.org</a>.</p>
+            <p>Below are general examples of packages that Freeform Portland is offering. The value of Underwriting spots are measured by the time of day that they are shared. The minimum underwriting agreement is 6 months, and we offer extra spots for businesses that sign up for 12 months or longer. We are also able to adjust the number of spots to fit any budget.</p>
+            <table>
+                <thead>
+                    <tr>
+                        <td colSpan="3"><strong>Basic Underwriting On-Air Mentions Per Month</strong></td>
+                    </tr>
+                    <tr>
+                        <td><b>$100 per month</b></td>
+                        <td><b>$200 per month</b></td>
+                        <td><b>$300 per month</b></td>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Two spots per week</td>
+                        <td>Four spots per week</td>
+                        <td>Eight spots per week</td>
+                    </tr>
+                    <tr>
+                        <td>1 Early Morning</td>
+                        <td>2 Early morning</td>
+                        <td>3 Early Morning</td>
+                    </tr>
+                    <tr>
+                        <td>1 Afternoon</td>
+                        <td>2 Afternoon</td>
+                        <td>2 Afternoon</td>
+                    </tr>
+                    <tr>
+                        <td />
+                        <td />
+                        <td>3 Evening</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p>Or if you want to make a tax-deductible, individual donation, you can do so by clicking <Link className={link} to="/donate">here</Link>.</p>
+        </article>
+    </main>
+);
+
+export default Underwriting;

--- a/src/js/components/underwriting/underwriting.css
+++ b/src/js/components/underwriting/underwriting.css
@@ -1,0 +1,22 @@
+:import('../../../css/classes/links.css') {
+    linkDefaults: linkDefaults;
+}
+
+:import('../../../css/rules/fonts.css') {
+    body: body;
+}
+
+:import('../../../css/rules/palette.css') {
+    linkColor: linkColor;
+}
+
+.content {
+    composes: mainContentWrapper from '../../../css/classes/wrappers.css';
+    font-family: body;
+}
+
+.link {
+    composes: linkDefaults;
+    color: linkColor;
+    text-decoration: underline;
+}

--- a/src/js/components/volunteer/index.js
+++ b/src/js/components/volunteer/index.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+    content,
+    bodyText,
+    bodyTextStyle,
+    heading,
+    subHeading,
+    link
+} from './volunteer.css';
+
+const Volunteer = () => (
+    <main className={content} role="main">
+        <article className={[bodyText, bodyTextStyle].join(' ')}>
+            <div>
+                <h2 className={heading}>Become a Freeform Portland Volunteer!</h2>
+                <p>Freeform Portland, KFFP-LP 90.30 FM, is a nonprofit, volunteer-run community radio station providing a number of public resources. Interested in becoming a Freeform Portland volunteer? Our volunteers gain job skills, learn about music, and meet new people all while giving back to their communities. It’s a great opportunity for people with a little bit of free time and a lot to gain. Our volunteer committees power the station in the following ways:</p>
+                <ul>
+                    <li>Broadcasting Operations</li>
+                    <li>Grant Writing</li>
+                    <li>Fundraising/Events</li>
+                    <li>Marketing</li>
+                    <li>Music Library</li>
+                    <li>Volunteer</li>
+                    <li>Website</li>
+                    <li>Zine</li>
+                </ul>
+                <p>Read more about each committee below, and fill out our <a className={link} href="https://docs.google.com/forms/d/e/1FAIpQLSeMMp97qi8aU429o-u_zS51cR15UrYUI7bIXFb5t9ZtLr7g6g/viewform?c=0&amp;w=1" target="_blank" rel="noopener">KFFP Volunteer Contact Form</a> to be contacted by a member of our Volunteer Committee.</p>
+                <h3 className={subHeading}>Broadcasting Operations</h3>
+                <p>Responsibilities include maintaining the station&#8217;s transmitter, turntables, microphones, wiring, and everything else that counts as broadcasting equipment. Members also collect and organize supplies for KFFP office operations.</p>
+                <h3 className={subHeading}>Grant Writing</h3>
+                <p>Grant writers obtain the vast majority of Freeform Portland&#8217;s financial support by soliciting grants from donor organizations. Good letter-writers should apply!</p>
+                <h3 className={subHeading}>Fundraising/Events</h3>
+                <p>This group plans and puts on shows, parties, DJ nights, and other events that help bring much-needed funds to KFFP. Members also help develop and distribute merch like t-shirts, pins, koozies, and more.</p>
+                <h3 className={subHeading}>Marketing</h3>
+                <p>Help raise community awareness of our station to bring in new listeners.</p>
+                <h3 className={subHeading}>Music Library</h3>
+                <p>This group keeps the music library stocked, organized, and in good working condition. Music Library Committee volunteers send music requests to record labels and tag new additions to help the KFFP community find what we&#8217;re looking for.</p>
+                <h3 className={subHeading}>Volunteer</h3>
+                <p>We always need new volunteers! This committee finds fresh meat and places people where they can be the most comfortable and effective at helping us out.</p>
+                <h3 className={subHeading}>Website</h3>
+                <p>Volunteers with website development skills (coding, project planning, etc.) should consider joining this committee. This is the crew that designs the site, writes the content, and develops the features like our streaming music player.</p>
+                <h3 className={subHeading}>Zine</h3>
+                <p>The Zine Committee solicits and creates art and copy, for our lovely Freeform Portland zine, and then publishes and distributes it four times per year for 25 cents an issue.</p>
+                <hr />
+                <p>Volunteering with us is a requirement for all of our on-air DJs. Don’t want to be on the air? No problem! Not everyone does, and we can still use your help. To learn more about volunteering with us, fill out the <a className={link} href="https://docs.google.com/forms/d/118lWyMgnMCVz3_xNOwMkUqXjYDnjq3wJPpVorB3BaBk/viewform?c=0&amp;w=1">KFFP Volunteer Contact Form</a> or email <a className={link} href="mailto:volunteer@freeformportland.org">volunteer@freeformportland.org</a>. Freeform Portland also accepts <a className={link} href="http://www.freeformportland.org/donate/" target="_blank">donations</a>!</p>
+            </div>
+        </article>
+    </main>
+);
+
+export default Volunteer;

--- a/src/js/components/volunteer/volunteer.css
+++ b/src/js/components/volunteer/volunteer.css
@@ -1,0 +1,35 @@
+:import('../../../css/classes/headings.css') {
+    subHeading: subHeading;
+    secondaryHeading: secondaryHeading;
+}
+
+:import('../../../css/classes/links.css') {
+    linkDefaults: linkDefaults;
+}
+
+:import('../../../css/rules/fonts.css') {
+    body: body;
+}
+
+:import('../../../css/rules/palette.css') {
+    linkColor: linkColor;
+}
+
+.content {
+    composes: mainContentWrapper from '../../../css/classes/wrappers.css';
+    font-family: body;
+}
+
+.heading {
+    composes: secondaryHeading;
+}
+
+.subHeading {
+    composes: subHeading;
+}
+
+.link {
+    composes: linkDefaults;
+    color: linkColor;
+    text-decoration: underline;
+}

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import About from './components/about';
+import Donate from './components/donate';
+import Faq from './components/faq';
+import Landing from './components/landing';
+import Underwriting from './components/underwriting';
+import Volunteer from './components/volunteer';
 
 // wrap <Route> and use this everywhere instead, then when
 // sub routes are added to any route it'll work
@@ -18,6 +23,26 @@ const routes = [
     {
         path: '/about',
         component: About
+    },
+    {
+        path: '/donate',
+        component: Donate
+    },
+    {
+        path: '/faq',
+        component: Faq
+    },
+    {
+        path: '/underwriting',
+        component: Underwriting
+    },
+    {
+        path: '/volunteer',
+        component: Volunteer
+    },
+    {
+        path: '/landing',
+        component: Landing
     }
 ];
 


### PR DESCRIPTION
Added components for all static content.

The CSS and HTML could use to be smoothed out and normalized, but it there's been a redesign to the site so I figure I should wait on dealing with that.

Everything adheres to what I set up for CSS modules but it lends itself to pretty repetitive component level stylesheets at this point. There might be a cleaner way to structure all that.

I've replaced anchors with `<Link />`s where appropriate and updated the route config. `<Landing />` should be the index but I wasn't sure how you wanted to handle the index route with the configuration you have so I just put it on a route '/landing' for the time being.

